### PR TITLE
changes in the teammgrd to support single process and config updates

### DIFF
--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -18,13 +18,18 @@ public:
             const std::vector<TableConnector> &tables);
 
     using Orch::doTask;
+    void ipcInitTeamd();
+    int sendIpcToTeamd(const std::string& command,
+                      const std::vector<std::string>& args);
     void cleanTeamProcesses();
+    void ipcCleanup();
 
 private:
     Table m_cfgMetadataTable;   // To retrieve MAC address
     Table m_cfgPortTable;
     Table m_cfgLagTable;
     Table m_cfgLagMemberTable;
+    Table m_cfgModeTable;
     Table m_statePortTable;
     Table m_stateLagTable;
     Table m_stateMACsecIngressSATable;
@@ -33,6 +38,8 @@ private:
     ProducerStateTable m_appLagTable;
 
     std::set<std::string> m_lagList;
+    bool m_teamdUnifiedProcMode = false;
+    int sockfd;
 
     MacAddress m_mac;
 
@@ -60,5 +67,8 @@ private:
     bool isMACsecIngressSAOk(const std::string &);
     uint16_t generateLacpKey(const std::string&);
 };
+
+#define TEAMD_MULTI_SOCK_PATH "/var/run/teamd/teamd-unified.sock"
+#define TEAMD_IPC_REQ "REQUEST"
 
 }

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -54,11 +54,13 @@ int main(int argc, char **argv)
 
         TableConnector conf_lag_table(&conf_db, CFG_LAG_TABLE_NAME);
         TableConnector conf_lag_member_table(&conf_db, CFG_LAG_MEMBER_TABLE_NAME);
+	TableConnector conf_teamd_mode_table(&conf_db, CFG_TEAMD_MODE_TABLE_NAME);
         TableConnector state_port_table(&state_db, STATE_PORT_TABLE_NAME);
 
         vector<TableConnector> tables = {
             conf_lag_table,
             conf_lag_member_table,
+	    conf_teamd_mode_table,
             state_port_table
         };
 
@@ -93,6 +95,7 @@ int main(int argc, char **argv)
             c->execute();
         }
         teammgr.cleanTeamProcesses();
+	teammgr.ipcCleanup(); 
         SWSS_LOG_NOTICE("Exiting");
     }
     catch (const exception &e)

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -54,13 +54,13 @@ int main(int argc, char **argv)
 
         TableConnector conf_lag_table(&conf_db, CFG_LAG_TABLE_NAME);
         TableConnector conf_lag_member_table(&conf_db, CFG_LAG_MEMBER_TABLE_NAME);
-	TableConnector conf_teamd_mode_table(&conf_db, CFG_TEAMD_MODE_TABLE_NAME);
+        TableConnector conf_teamd_mode_table(&conf_db, CFG_TEAMD_MODE_TABLE_NAME);
         TableConnector state_port_table(&state_db, STATE_PORT_TABLE_NAME);
 
         vector<TableConnector> tables = {
             conf_lag_table,
             conf_lag_member_table,
-	    conf_teamd_mode_table,
+            conf_teamd_mode_table,
             state_port_table
         };
 
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
             c->execute();
         }
         teammgr.cleanTeamProcesses();
-	teammgr.ipcCleanup(); 
+	teammgr.ipcCleanup();
         SWSS_LOG_NOTICE("Exiting");
     }
     catch (const exception &e)

--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -254,8 +254,8 @@ TeamSync::TeamPortSync::TeamPortSync(const string &lagName, int ifindex,
     {
         try
         {
-	    m_nl = team_netlink_alloc();
-	    if (!m_nl)
+            m_nl = team_netlink_alloc();
+            if (!m_nl)
             {
                 throw system_error(make_error_code(errc::address_not_available),
                                    "Unable to allocate team netlink socket");
@@ -271,9 +271,9 @@ TeamSync::TeamPortSync::TeamPortSync(const string &lagName, int ifindex,
             if (err)
             {
                 team_free(m_team);
-		team_netlink_free(m_nl);
+                team_netlink_free(m_nl);
                 m_team = NULL;
-		m_nl = NULL;
+                m_nl = NULL;
                 throw system_error(make_error_code(errc::address_not_available),
                                    "Unable to initialize team socket");
             }
@@ -282,8 +282,8 @@ TeamSync::TeamPortSync::TeamPortSync(const string &lagName, int ifindex,
             if (err)
             {
                 team_free(m_team);
-		team_netlink_free(m_nl);
-		m_nl = NULL;
+                team_netlink_free(m_nl);
+                m_nl = NULL;
                 m_team = NULL;
                 throw system_error(make_error_code(errc::address_not_available),
                                    "Unable to register port change event");
@@ -317,7 +317,7 @@ TeamSync::TeamPortSync::~TeamPortSync()
     {
         team_change_handler_unregister(m_team, &gPortChangeHandler, this);
         team_free(m_team);
-	team_netlink_free(m_nl);
+        team_netlink_free(m_nl);
     }
 }
 

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -53,6 +53,7 @@ public:
         static const struct team_change_handler gPortChangeHandler;
     private:
         ProducerStateTable *m_lagMemberTable;
+	struct team_netlink *m_nl;
         struct team_handle *m_team;
         std::string m_lagName;
         int m_ifindex;

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -53,7 +53,7 @@ public:
         static const struct team_change_handler gPortChangeHandler;
     private:
         ProducerStateTable *m_lagMemberTable;
-	struct team_netlink *m_nl;
+        struct team_netlink *m_nl;
         struct team_handle *m_team;
         std::string m_lagName;
         int m_ifindex;

--- a/tests/mock_tests/teammgrd/teamd_ipc.h
+++ b/tests/mock_tests/teammgrd/teamd_ipc.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <vector>
+#include <string>
+#include "orch.h"
+
+// Weak declaration
+__attribute__((weak)) int send_ipc_to_teamd(const std::string &method, const std::vector<std::string> &args);

--- a/tests/mock_tests/teammgrd/teammgr_ut.cpp
+++ b/tests/mock_tests/teammgrd/teammgr_ut.cpp
@@ -161,7 +161,7 @@ namespace teammgr_ut
             std::vector<swss::FieldValueTuple> vec;
             vec.emplace_back("mac", "01:23:45:67:89:ab");
             metadata_table.set("localhost", vec);
-	    swss::Table cfg_mode_table = swss::Table(m_config_db.get(), CFG_TEAMD_MODE_TABLE_NAME);
+            swss::Table cfg_mode_table = swss::Table(m_config_db.get(), CFG_TEAMD_MODE_TABLE_NAME);
             cfg_mode_table.set("GLOBAL",{ {"mode","multi-process"} });
 
             TableConnector conf_lag_table(m_config_db.get(), CFG_LAG_TABLE_NAME);
@@ -202,7 +202,7 @@ namespace teammgr_ut
         teammgr.addExistingData(&cfg_lag_table);
         teammgr.doTask();
         ASSERT_NE(mockCallArgs.size(), 0);
-	ASSERT_FALSE(mockCallArgs.empty());
+        ASSERT_FALSE(mockCallArgs.empty());
         EXPECT_NE(mockCallArgs.front().find("/usr/bin/teamd -r -t PortChannel382"), std::string::npos);
         EXPECT_EQ(mockCallArgs.size(), 1);
         EXPECT_EQ(mockKillCommands.size(), 1);
@@ -287,7 +287,7 @@ namespace teammgr_ut
     {
         swss::Table cfg_mode_table(m_config_db.get(), CFG_TEAMD_MODE_TABLE_NAME);
         swss::Table cfg_lag_table(m_config_db.get(), CFG_LAG_TABLE_NAME);
-	cfg_mode_table.del("GLOBAL");
+        cfg_mode_table.del("GLOBAL");
         cfg_lag_table.set("PortChannel123", {
             {"admin_status", "up"},
             {"mtu", "9100"},

--- a/tlm_teamd/main.cpp
+++ b/tlm_teamd/main.cpp
@@ -88,15 +88,15 @@ int main()
     {
         swss::Logger::linkToDbNative("tlm_teamd");
         SWSS_LOG_NOTICE("Starting");
-	swss::DBConnector db("STATE_DB", 0);
-	ValuesStore values_store(&db);
-	TeamdCtlMgr teamdctl_mgr;
+        swss::DBConnector db("STATE_DB", 0);
+        ValuesStore values_store(&db);
+        TeamdCtlMgr teamdctl_mgr;
 
         swss::Select s;
         swss::Selectable * event;
         swss::SubscriberStateTable sst_lag(&db, STATE_LAG_TABLE_NAME);
         s.addSelectable(&sst_lag);
-	swss::DBConnector config_db("CONFIG_DB", 0);
+        swss::DBConnector config_db("CONFIG_DB", 0);
 
         swss::Table table(&config_db, "TEAMD");
         std::vector<swss::FieldValueTuple> values;
@@ -115,12 +115,12 @@ int main()
                     break;
                 }
             }
-	}
-    	if (m_teamdMultiProcMode == "multi-process") {
-		teamdctl_mgr.m_teamdUnifiedProcMode = false;
-    	} else {
-		teamdctl_mgr.m_teamdUnifiedProcMode = true;
-	}
+        }
+        if (m_teamdMultiProcMode == "multi-process") {
+            teamdctl_mgr.m_teamdUnifiedProcMode = false;
+        } else {
+            teamdctl_mgr.m_teamdUnifiedProcMode = true;
+        }
 
 
         while (g_run && rc == 0)

--- a/tlm_teamd/teamdctl_mgr.cpp
+++ b/tlm_teamd/teamdctl_mgr.cpp
@@ -4,9 +4,14 @@
 #include <logger.h>
 
 #include "teamdctl_mgr.h"
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <cstring>
+#include <errno.h>
+#include <sstream>
 
 #define MAX_RETRY 3
-
 ///
 /// Custom function for libteamdctl logger. IT is empty to prevent libteamdctl to spam us with the error messages
 /// @param tdc teamdctl descriptor
@@ -30,13 +35,15 @@ void teamdctl_log_function(struct teamdctl *tdc, int priority,
 ///
 TeamdCtlMgr::~TeamdCtlMgr()
 {
-    for (const auto & p: m_handlers)
-    {
-        const auto & lag_name = p.first;
-        const auto & tdc = m_handlers[lag_name];
-        teamdctl_disconnect(tdc);
-        teamdctl_free(tdc);
-        SWSS_LOG_NOTICE("Exiting. Disconnecting from teamd. LAG '%s'", lag_name.c_str());
+    if (!m_teamdUnifiedProcMode) {
+        for (const auto & p: m_handlers)
+        {
+            const auto & lag_name = p.first;
+            const auto & tdc = m_handlers[lag_name];
+            teamdctl_disconnect(tdc);
+            teamdctl_free(tdc);
+            SWSS_LOG_NOTICE("Exiting. Disconnecting from teamd. LAG '%s'", lag_name.c_str());
+	}
     }
 }
 
@@ -77,40 +84,45 @@ bool TeamdCtlMgr::add_lag(const std::string & lag_name)
 ///
 bool TeamdCtlMgr::try_add_lag(const std::string & lag_name)
 {
-    if (m_lags_to_add.find(lag_name) == m_lags_to_add.end())
+
+    if (m_teamdUnifiedProcMode)
     {
-        m_lags_to_add[lag_name] = 0;
+        SWSS_LOG_NOTICE("In default. LAG='%s' will be handled via IPC.", lag_name.c_str());
+        m_handlers.emplace(lag_name, nullptr);  
+        return true;
     }
 
-    int attempt = m_lags_to_add[lag_name];
-
-    auto tdc = teamdctl_alloc();
-    if (!tdc)
-    {
-        SWSS_LOG_ERROR("Can't allocate memory for teamdctl handler. LAG='%s'. attempt=%d", lag_name.c_str(), attempt);
-        m_lags_to_add[lag_name]++;
-        return false;
+    else {
+	    if (m_lags_to_add.find(lag_name) == m_lags_to_add.end())
+	    {
+	    	    m_lags_to_add[lag_name] = 0;
+	    }
+	
+	    int attempt = m_lags_to_add[lag_name];
+	    auto tdc = teamdctl_alloc();
+	    if (!tdc)
+	    {
+	    	    SWSS_LOG_ERROR("Can't allocate memory for teamdctl handler. LAG='%s'. attempt=%d", lag_name.c_str(), attempt);
+	    	    m_lags_to_add[lag_name]++;
+	    	    return false;
+	    }
+	    teamdctl_set_log_fn(tdc, &teamdctl_log_function);
+	    int err = teamdctl_connect(tdc, lag_name.c_str(), nullptr, "usock");
+	    if (err)
+	    {
+		    if (attempt != 0)
+	    	    {
+			    SWSS_LOG_WARN("Can't connect to teamd LAG='%s', error='%s'. attempt=%d", lag_name.c_str(), strerror(-err), attempt);
+	    	    }
+	    	    teamdctl_free(tdc);
+	    	    m_lags_to_add[lag_name]++;
+	    	    return false;
+	    }
+	    m_handlers.emplace(lag_name, tdc);
+	    m_lags_to_add.erase(lag_name);
+	    SWSS_LOG_NOTICE("The LAG '%s' has been added.", lag_name.c_str());
+	    return true;
     }
-
-    teamdctl_set_log_fn(tdc, &teamdctl_log_function);
-
-    int err = teamdctl_connect(tdc, lag_name.c_str(), nullptr, "usock");
-    if (err)
-    {
-        if (attempt != 0)
-        {
-            SWSS_LOG_WARN("Can't connect to teamd LAG='%s', error='%s'. attempt=%d", lag_name.c_str(), strerror(-err), attempt);
-        }
-        teamdctl_free(tdc);
-        m_lags_to_add[lag_name]++;
-        return false;
-    }
-
-    m_handlers.emplace(lag_name, tdc);
-    m_lags_to_add.erase(lag_name);
-    SWSS_LOG_NOTICE("The LAG '%s' has been added.", lag_name.c_str());
-
-    return true;
 }
 
 ///
@@ -121,13 +133,20 @@ bool TeamdCtlMgr::try_add_lag(const std::string & lag_name)
 ///
 bool TeamdCtlMgr::remove_lag(const std::string & lag_name)
 {
+
     if (has_key(lag_name))
     {
-        auto tdc = m_handlers[lag_name];
-        teamdctl_disconnect(tdc);
-        teamdctl_free(tdc);
-        m_handlers.erase(lag_name);
-        SWSS_LOG_NOTICE("The LAG '%s' has been removed.", lag_name.c_str());
+	if (m_teamdUnifiedProcMode) 
+        {
+		m_handlers.erase(lag_name);
+	}
+	else {
+		auto tdc = m_handlers[lag_name];
+	   	teamdctl_disconnect(tdc);
+		teamdctl_free(tdc);
+		m_handlers.erase(lag_name);
+	}
+        SWSS_LOG_NOTICE("The LAG '%s' has been removed from db.", lag_name.c_str());
     }
     else if (m_lags_to_add.find(lag_name) != m_lags_to_add.end())
     {
@@ -184,19 +203,22 @@ TeamdCtlDump TeamdCtlMgr::get_dump(const std::string & lag_name, bool to_retry)
     TeamdCtlDump res = { false, "" };
     if (has_key(lag_name))
     {
-        auto tdc = m_handlers[lag_name];
-        char * dump;
-        int r = teamdctl_state_get_raw_direct(tdc, &dump);
-        if (r == 0)
-        {
-            res = { true, std::string(dump) };
 
-            // If this lag interface errored last time, remove the entry
-            if (m_lags_err_retry.find(lag_name) != m_lags_err_retry.end())
+     if (m_teamdUnifiedProcMode) 
+     {
+    
+        std::string ipc_response;
+        int ret = sendIpcToTeamd("StateDump", {lag_name}, ipc_response); // Send the IPC request
+        if (ret == 0)
+
+        {
+	    auto pos = ipc_response.find('{');
+            if (pos != std::string::npos)
             {
-                SWSS_LOG_NOTICE("The LAG '%s' had errored in get_dump earlier, removing it", lag_name.c_str());
-                m_lags_err_retry.erase(lag_name);
+                ipc_response.erase(0, pos);
             }
+            res = {true, ipc_response}; // Get the response from teamd via IPC
+            m_lags_err_retry.erase(lag_name); // Clear retry count on success
         }
         else
         {
@@ -217,15 +239,59 @@ TeamdCtlDump TeamdCtlMgr::get_dump(const std::string & lag_name, bool to_retry)
                 {
 
                     // This time a different lag interface errored out.
-		    m_lags_err_retry[lag_name] = 1;
+                    m_lags_err_retry[lag_name] = 1;
                 }
             }
+
             else
             {
                 // No need to retry if the flag is not set.
                 SWSS_LOG_ERROR("Can't get dump for LAG '%s'. Skipping", lag_name.c_str());
             }
         }
+
+     } else {
+     	     auto tdc = m_handlers[lag_name];
+       	     char * dump;
+     	     int r = teamdctl_state_get_raw_direct(tdc, &dump);
+     	     if (r == 0)
+     	     {
+	 	     res = { true, std::string(dump) };
+	 	     // If this lag interface errored last time, remove the entry
+                     if (m_lags_err_retry.find(lag_name) != m_lags_err_retry.end())
+	 	     {
+	     		     SWSS_LOG_NOTICE("The LAG '%s' had errored in get_dump earlier, removing it", lag_name.c_str());
+		     	     m_lags_err_retry.erase(lag_name);
+	 	     }
+     	     }
+     	     else
+     	     {
+	 	     // In case of failure and retry flag is set, check if it fails for MAX_RETRY times.
+                     if (to_retry)
+	 	     {
+	     		     if (m_lags_err_retry.find(lag_name) != m_lags_err_retry.end())
+	     		     {
+		 		     if (m_lags_err_retry[lag_name] == MAX_RETRY)
+		 		     {
+		     			     SWSS_LOG_ERROR("Can't get dump for LAG '%s'. Skipping", lag_name.c_str());
+		     			     m_lags_err_retry.erase(lag_name);
+		 		     }
+		 		     else
+		     			     m_lags_err_retry[lag_name]++;
+	     		     }
+	     		     else
+	     		     {
+		 		     // This time a different lag interface errored out.
+		                     m_lags_err_retry[lag_name] = 1;
+	     		     }
+	 	     }
+	 	     else
+	 	     {
+	     		     // No need to retry if the flag is not set.
+                             SWSS_LOG_ERROR("Can't get dump for LAG '%s'. Skipping", lag_name.c_str());
+	 	     }
+     	     }
+     }
     }
     else
     {
@@ -256,5 +322,65 @@ TeamdCtlDumps TeamdCtlMgr::get_dumps(bool to_retry)
     }
 
     return res;
+}
+
+
+int TeamdCtlMgr::sendIpcToTeamd(const std::string& command,
+                      const std::vector<std::string>& args,
+                      std::string& response_out)
+{
+    int sockfd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (sockfd < 0)
+    {
+        SWSS_LOG_ERROR("Failed to create socket: %s", strerror(errno));
+        return -1;
+    }
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, TEAMD_MULTI_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+    if (connect(sockfd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+    {
+        close(sockfd);
+        return -1;
+    }
+
+    std::ostringstream message;
+    message << TEAMD_IPC_REQ << "\n" << command << "\n";
+
+    for (size_t i = 0; i < args.size(); ++i)
+    {
+        message << args[i] << "\n";
+    }
+
+    std::string final_msg = message.str();
+    SWSS_LOG_NOTICE("Sending IPC message to teamd:\n%s", final_msg.c_str());
+
+    ssize_t sent = send(sockfd, final_msg.c_str(), final_msg.length(), 0);
+    if (sent < 0)
+    {
+        SWSS_LOG_ERROR("Failed to send message to teamd: %s", strerror(errno));
+        close(sockfd);
+        return -1;
+    }
+
+    char buffer[65536];
+    ssize_t received = recv(sockfd, buffer, sizeof(buffer) - 1, 0);
+    if (received > 0)
+    {
+        buffer[received] = '\0';
+        response_out = std::string(buffer);
+	SWSS_LOG_NOTICE("Response from teamd to teammgrd: %s", buffer);
+        close(sockfd);
+        return 0;
+    }
+    else
+    {
+        SWSS_LOG_WARN("No response from teamd or recv failed: %s", strerror(errno));
+        close(sockfd);
+        return -1;
+    }
 }
 

--- a/tlm_teamd/teamdctl_mgr.h
+++ b/tlm_teamd/teamdctl_mgr.h
@@ -21,6 +21,11 @@ public:
     // Retry logic added to prevent incorrect error reporting in dump API's
     TeamdCtlDump get_dump(const std::string & lag_name, bool to_retry);
     TeamdCtlDumps get_dumps(bool to_retry);
+    int sendIpcToTeamd(const std::string& command,
+                      const std::vector<std::string>& args,
+                      std::string& response_out);
+    bool m_teamdUnifiedProcMode = false;
+
 
 private:
     bool has_key(const std::string & lag_name) const;
@@ -29,6 +34,11 @@ private:
     std::unordered_map<std::string, struct teamdctl*> m_handlers;
     std::unordered_map<std::string, int> m_lags_to_add;
     std::unordered_map<std::string, int> m_lags_err_retry;
+    int sockfd;
 
     const int max_attempts_to_add = 10;
 };
+
+
+#define TEAMD_MULTI_SOCK_PATH "/var/run/teamd/teamd-unified.sock"
+#define TEAMD_IPC_REQ "REQUEST"


### PR DESCRIPTION
**Mode-Based Process Initialization via Redis:-**
1.Subscribe and listen to mode configuration in Redis to decide and initialize either single or multiple teamd processes accordingly.
2.Send PortChannel create/del requests via IPC based on mode configuration
3.send Port member add/del requests from teammgrd via ipc with portchannel name

**please find the attached test logs.**
[teammgrd_log.txt](https://github.com/user-attachments/files/21315966/teammgrd_log.txt)

**Mock_test logs:**
<img width="1920" height="1080" alt="lcov_report" src="https://github.com/user-attachments/assets/8c41cf6d-6262-41b3-b91e-27eeff38683e" />
